### PR TITLE
Fixed Close Button opening Home page directly

### DIFF
--- a/frontend/src/components/StudentLogin.js
+++ b/frontend/src/components/StudentLogin.js
@@ -40,7 +40,7 @@ function StudentLogin() {
   };
 
   const handleCloseModal = () => {
-    navigate('/'); // Navigate back to home page when modal is closed
+    navigate(-1); // Navigate back to last visited page when modal is closed
   };
 
   return (

--- a/frontend/src/components/StudentSignup.js
+++ b/frontend/src/components/StudentSignup.js
@@ -55,7 +55,7 @@ function StudentLogin() {
           {error && <div style={{ color: 'red' }}>{error}</div>}
           <p>Already have an account?</p>
           <button onClick={() => navigate(-1)}>Login</button>
-          <button type='button' onClick={() => window.history.go(-2)}>Close</button>
+          <button type='button' onClick={() => navigate(-2)}>Close</button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
The "Close" button on login page was still pointing to "Home" Page.

Replaced window.history.go(-2) with navigate(-2) because navigate is more compatible with React. While using window.log may cause page reload and other potential errors as React is not aware of that change.